### PR TITLE
Adjust ticket printing and button highlight

### DIFF
--- a/app.js
+++ b/app.js
@@ -71,7 +71,13 @@ document.getElementById('btnNextFromSource').addEventListener('click', () => {
 
 // Back from products to source
 const backToSourceBtn = document.getElementById('backToSource');
-if (backToSourceBtn) backToSourceBtn.addEventListener('click', () => showScreen('source'));
+if (backToSourceBtn) backToSourceBtn.addEventListener('click', () => {
+  // Clear visual highlight on previously selected source options
+  document.querySelectorAll('.btn-col[data-group] .option.selected').forEach(x => x.classList.remove('selected'));
+  // Also clear special selection highlight
+  document.querySelectorAll('[data-special].selected').forEach(x => x.classList.remove('selected'));
+  showScreen('source');
+});
 
 // From products proceed to weights
 const proceedBtn = document.getElementById('btnProceedWeights');
@@ -283,6 +289,24 @@ function buildBarcodePayload() {
 // Simple Code128-like placeholder barcode (not spec-perfect, but scannable as Code39)
 function drawBarcode(canvas, text) {
   const ctx = canvas.getContext('2d');
+  // Ensure canvas fits its parent container
+  const parent = canvas.parentElement;
+  if (parent) {
+    const maxWidth = parent.clientWidth || 320;
+    const maxHeight = parent.clientHeight || 120;
+    // Preserve original aspect ratio based on current canvas size
+    const aspect = canvas.height > 0 ? canvas.width / canvas.height : (320/120);
+    let targetWidth = Math.min(maxWidth, Math.round(maxHeight * aspect));
+    let targetHeight = Math.round(targetWidth / aspect);
+    if (targetHeight > maxHeight) {
+      targetHeight = maxHeight;
+      targetWidth = Math.round(targetHeight * aspect);
+    }
+    if (canvas.width !== targetWidth || canvas.height !== targetHeight) {
+      canvas.width = targetWidth;
+      canvas.height = targetHeight;
+    }
+  }
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   // We'll draw a simple Code39 style pattern using a basic library-free approach
   const code39 = {
@@ -299,11 +323,12 @@ function drawBarcode(canvas, text) {
     '/':'100100101001', '+':'100101001001', '%':'101001001001', '*':'100101101101'
   };
   const content = `*${text.toUpperCase()}*`;
-  const narrow = 2; // px
+  // Scale bar width relative to canvas size to keep barcode within bounds
+  const narrow = Math.max(1, Math.floor(canvas.width / 200));
   const wide = narrow * 3;
-  let x = 10;
-  const y = 10;
-  const height = canvas.height - 20;
+  let x = narrow * 3;
+  const y = narrow * 3;
+  const height = canvas.height - y * 2;
   ctx.fillStyle = '#000';
   for (const ch of content) {
     const pattern = code39[ch];

--- a/styles.css
+++ b/styles.css
@@ -84,7 +84,13 @@ body {
 
 /* Print styles: hide chrome, fit label to page */
 @media print {
-  body { background: #fff; }
+  @page { size: 6in 4in; margin: 0; }
+  html, body { height: auto; background: #fff; }
+  #app { padding: 0; }
+  .screen { display: none !important; }
+  #screen-preview { display: block !important; }
   .screen-header, .preview-actions { display: none !important; }
-  .label-canvas { width: 100%; height: auto; box-shadow: none; }
+  .preview-layout { display: block; }
+  .label-canvas { width: 6in; height: 4in; margin: 0 auto; box-shadow: none; }
+  .barcode canvas { width: 100%; height: auto; }
 }


### PR DESCRIPTION
Adjust print ticket size to 6x4 inches, ensure barcode fits within the white area, and clear source selection highlights when navigating back.

---
<a href="https://cursor.com/background-agent?bcId=bc-b3613d35-dd19-49b0-b09c-3947c4e39fab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b3613d35-dd19-49b0-b09c-3947c4e39fab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

