### PR TITLE
Fix unclickable source code

### DIFF
--- a/app.js
+++ b/app.js
@@ -228,6 +228,23 @@ document.getElementById('clearPreview').addEventListener('click', () => {
   updatePreview();
 });
 
+// Make SOURCE value in preview clickable to return to source selection
+const sourceChosenEl = document.getElementById('sourceChosen');
+if (sourceChosenEl) {
+  sourceChosenEl.setAttribute('role', 'button');
+  sourceChosenEl.setAttribute('tabindex', '0');
+  sourceChosenEl.setAttribute('title', 'Click to change source');
+  sourceChosenEl.addEventListener('click', () => {
+    showScreen('source');
+  });
+  sourceChosenEl.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      showScreen('source');
+    }
+  });
+}
+
 // Preview fill and barcode rendering
 function lbToKg(lb) { return +(lb * 0.45359237).toFixed(1); }
 

--- a/styles.css
+++ b/styles.css
@@ -80,6 +80,7 @@ body {
 .unit { font-size: 12px; }
 .unit span { font-size: 36px; font-weight: 800; letter-spacing: 2px; }
 .material { font-weight: 700; margin-bottom: 8px; }
+.material #sourceChosen { text-decoration: underline; cursor: pointer; }
 .barcode { display: flex; justify-content: flex-end; }
 
 /* Print styles: hide chrome, fit label to page */


### PR DESCRIPTION
Make the "SOURCE" value in the preview clickable to allow users to easily return to the source selection screen.

---
<a href="https://cursor.com/background-agent?bcId=bc-6c0ee1f3-1052-425e-9ade-a23ea598ca4a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6c0ee1f3-1052-425e-9ade-a23ea598ca4a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

