### PR TITLE
Fix unresponsive choose source buttons

### DIFF
--- a/app.js
+++ b/app.js
@@ -48,6 +48,36 @@ document.querySelectorAll('.btn-col[data-group] .option').forEach(btn => {
   });
 });
 
+// Defensive: also handle clicks via event delegation in case direct listeners fail to bind
+const sourceScreenEl = document.getElementById('screen-source');
+if (sourceScreenEl) {
+  sourceScreenEl.addEventListener('click', (event) => {
+    const optionBtn = event.target && event.target.closest && event.target.closest('.btn-col[data-group] .option');
+    if (optionBtn && sourceScreenEl.contains(optionBtn)) {
+      const groupCol = optionBtn.closest('.btn-col[data-group]');
+      if (groupCol) {
+        const group = groupCol.getAttribute('data-group');
+        groupCol.querySelectorAll('.option').forEach(x => x.classList.remove('selected'));
+        optionBtn.classList.add('selected');
+        state.source[group] = optionBtn.dataset.value;
+        state.activeGroup = group;
+        state.selectedProduct = null;
+        renderProductList();
+        const proceedBtnLocal = document.getElementById('btnProceedWeights');
+        if (proceedBtnLocal) proceedBtnLocal.disabled = true;
+        showScreen('products');
+      }
+    }
+
+    const specialBtn = event.target && event.target.closest && event.target.closest('[data-special]');
+    if (specialBtn && sourceScreenEl.contains(specialBtn)) {
+      sourceScreenEl.querySelectorAll('[data-special]').forEach(x => x.classList.remove('selected'));
+      specialBtn.classList.add('selected');
+      state.source.special = specialBtn.getAttribute('data-special');
+    }
+  });
+}
+
 document.querySelectorAll('[data-special]').forEach(btn => {
   btn.addEventListener('click', () => {
     document.querySelectorAll('[data-special]').forEach(x => x.classList.remove('selected'));


### PR DESCRIPTION
Fix non-responsive 'choose source' buttons by adding event delegation to the source screen.

The direct click handlers for these buttons were not consistently firing, causing the UI to be unresponsive. Event delegation ensures clicks are reliably captured and processed.

---
<a href="https://cursor.com/background-agent?bcId=bc-fa3ce69e-7db7-4b2c-ae83-6422c0c40f6e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fa3ce69e-7db7-4b2c-ae83-6422c0c40f6e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

