### PR TITLE
Replace label text with Nylene logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,7 +150,7 @@
         <div class="label-canvas" id="labelCanvas">
           <div class="label-header">
             <div class="made">PACKAGED/EMBALLÉ ON <span id="pkgDate"></span><br>MADE IN CANADA - FABRIQUÉ AU CANADA</div>
-            <img class="logo" alt="Logo" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='60'%3E%3Ctext x='0' y='45' font-family='Arial' font-size='40'%3ENylene%3C/text%3E%3C/svg%3E">
+            <img class="logo" alt="Logo" src="https://nylene.com/wp-content/uploads/2023/03/NYLENE-LOGO-Web.svg">
           </div>
           <div class="big-code" id="bigCode">BX3WQ662</div>
           <div class="weights">


### PR DESCRIPTION
Replace the inline 'Nylene' text SVG with the official Nylene logo SVG.

---
<a href="https://cursor.com/background-agent?bcId=bc-b8bb08b7-3302-4e3d-9039-eed0cc0d4adc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b8bb08b7-3302-4e3d-9039-eed0cc0d4adc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

