### PR TITLE
Format data for AirTrack DP-1 printer

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -277,7 +277,7 @@ body {
 /* Print styles: hide chrome, fit label to page */
 @media print {
     @page {
-        size: 110mm 152mm;
+        size: 101.6mm 152.4mm;
         margin: 0;
     }
     html,
@@ -302,10 +302,28 @@ body {
         display: block;
     }
     .label-canvas {
-        width: 110mm;
-        height: 152mm;
+        width: 101.6mm;
+        height: 152.4mm;
+        padding: 5mm;
         margin: 0 auto;
         box-shadow: none;
+    }
+    /* Ensure footer grid fits the 110mm width; avoid fixed pixel overflow */
+    .footer-row {
+        grid-template-columns: 1fr auto 40mm;
+        gap: 4mm;
+    }
+    /* Tweak typography to prevent wrapping/clipping on thermal printers */
+    .big-code {
+        font-size: 64px;
+        letter-spacing: 2px;
+    }
+    .w-values {
+        font-size: 22px;
+    }
+    .unit span {
+        font-size: 50px;
+        letter-spacing: 1px;
     }
     .barcode canvas {
         width: 100%;


### PR DESCRIPTION
Adjust print styles to fit AirTrack DP-1 printer labels by setting exact page dimensions and reducing font sizes.

---
<a href="https://cursor.com/background-agent?bcId=bc-ec934060-276e-40f8-8520-eb4a84bb419f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ec934060-276e-40f8-8520-eb4a84bb419f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

