### PR TITLE
Swap big code and unit number in preview

### DIFF
--- a/app.js
+++ b/app.js
@@ -258,7 +258,7 @@ function updatePreview() {
     )}:${pad(now.getSeconds())}`;
     document.getElementById("pkgDate").textContent = stamp;
 
-    document.getElementById("bigCode").textContent = state.bigCode;
+    document.getElementById("bigCode").textContent = state.unitNumber;
 
     const grossLb = state.weights.grossLb;
     const netLb = state.weights.netLb;
@@ -274,7 +274,7 @@ function updatePreview() {
         tareLbEl.textContent = tareLb.toFixed(1);
     }
 
-    document.getElementById("unitNumber").textContent = state.unitNumber;
+    document.getElementById("unitNumber").textContent = state.bigCode;
     drawBarcode(
         document.getElementById("barcodeCanvas"),
         buildBarcodePayload()
@@ -285,7 +285,7 @@ function updatePreview() {
     const sourceEl = document.getElementById("sourceChosen");
     const allSelEl = document.getElementById("allSelections");
     if (productEl)
-        productEl.textContent = state.selectedProduct || state.bigCode || "—";
+        productEl.textContent = state.bigCode || "—";
     if (sourceEl) {
         const group = state.activeGroup;
         const letter = group ? state.source[group] : null;
@@ -320,9 +320,7 @@ function buildBarcodePayload() {
     const sp = state.source.special
         ? ` SP ${sanitizeCode39(state.source.special)}`
         : "";
-    const product = sanitizeCode39(
-        state.selectedProduct || state.bigCode || "NA"
-    );
+    const product = sanitizeCode39(state.bigCode || "NA");
     const net = Number(state.weights.netLb || 0).toFixed(1);
     const gro = Number(state.weights.grossLb || 0).toFixed(1);
     const tar = Number(state.weights.tareLb || 0).toFixed(1);
@@ -433,7 +431,7 @@ function buildLogRecord() {
     return {
         timestamp: toIso(now),
         unitNumber: state.unitNumber,
-        product: state.selectedProduct || state.bigCode,
+        product: state.bigCode,
         sourceGroup: group,
         sourceLetter: letter,
         special: state.source.special || "",

--- a/modules/logs.js
+++ b/modules/logs.js
@@ -25,7 +25,7 @@ export function buildLogRecord() {
     return {
         timestamp: toIso(now),
         unitNumber: state.unitNumber,
-        product: state.selectedProduct || state.bigCode,
+        product: state.bigCode,
         sourceGroup: group,
         sourceLetter: letter,
         special: state.source.special || '',

--- a/modules/payload.js
+++ b/modules/payload.js
@@ -7,7 +7,7 @@ export function buildBarcodePayload() {
     const letter = group ? state.source[group] || '' : '';
     const src = group && letter ? `${group.toUpperCase()}-${letter}` : 'NA';
     const sp = state.source.special ? ` SP ${sanitizeCode39(state.source.special)}` : '';
-    const product = sanitizeCode39(state.selectedProduct || state.bigCode || 'NA');
+    const product = sanitizeCode39(state.bigCode || 'NA');
     const net = Number(state.weights.netLb || 0).toFixed(1);
     const gro = Number(state.weights.grossLb || 0).toFixed(1);
     const tar = Number(state.weights.tareLb || 0).toFixed(1);

--- a/modules/steps/preview.js
+++ b/modules/steps/preview.js
@@ -40,7 +40,7 @@ function updatePreview() {
     if (pkgDate) pkgDate.textContent = stamp;
 
     const bigCode = document.getElementById('bigCode');
-    if (bigCode) bigCode.textContent = state.bigCode;
+    if (bigCode) bigCode.textContent = state.unitNumber;
 
     const grossLb = state.weights.grossLb;
     const netLb = state.weights.netLb;
@@ -59,14 +59,14 @@ function updatePreview() {
     if (tareLbEl) tareLbEl.textContent = tareLb.toFixed(1);
 
     const unit = document.getElementById('unitNumber');
-    if (unit) unit.textContent = state.unitNumber;
+    if (unit) unit.textContent = state.bigCode;
 
     const canvas = document.getElementById('barcodeCanvas');
     if (canvas) drawBarcode(canvas, buildBarcodePayload());
 
     const productEl = document.getElementById('productName');
     const sourceEl = document.getElementById('sourceChosen');
-    if (productEl) productEl.textContent = state.selectedProduct || state.bigCode || '—';
+    if (productEl) productEl.textContent = state.bigCode || '—';
     if (sourceEl) {
         const group = state.activeGroup;
         const letter = group ? state.source[group] : null;


### PR DESCRIPTION
Swap `bigCode` and `unitNumber` in the preview display and ensure the product selected is always `bigCode`.

---
<a href="https://cursor.com/background-agent?bcId=bc-7dfaf50d-3ae1-4438-a295-0408a5df2257">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7dfaf50d-3ae1-4438-a295-0408a5df2257">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

