### PR TITLE
Shorten long barcode

### DIFF
--- a/modules/barcode.js
+++ b/modules/barcode.js
@@ -13,7 +13,7 @@ export function drawBarcode(canvas, text) {
                 background: '#ffffff00',
                 lineColor: '#000000',
                 margin: 10,              // quiet zone
-                width: 2,                // bar width for better readability
+                width: 1,                // narrower bars to shorten overall length
                 height: Math.max(40, canvas.height - 20),
                 textMargin: 0,
             });

--- a/styles.css
+++ b/styles.css
@@ -312,7 +312,7 @@ body {
         box-shadow: none;
     }
     .barcode canvas {
-        width: 100%;
+        width: 65%;
         height: auto;
     }
 }


### PR DESCRIPTION
Reduce barcode length by decreasing bar width and limiting print width in print mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-b72f954d-3135-4d29-9d29-3b95d6f1f6b0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b72f954d-3135-4d29-9d29-3b95d6f1f6b0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

