### PR TITLE
Prevent counter increment without label

### DIFF
--- a/modules/steps/preview.js
+++ b/modules/steps/preview.js
@@ -1,4 +1,5 @@
 import { state, showScreen } from "../state.js";
+import { generateUnitNumber, commitPrintedUnitNumber } from "../utils/generators.js";
 import { lbToKg } from "../utils/format.js";
 import { drawBarcode } from "../barcode.js";
 import { buildBarcodePayload } from "../payload.js";
@@ -27,6 +28,10 @@ export function initPreviewStep() {
                 try {
                     await appendLogRecord();
                     appendHistoryRecord();
+                    // Commit the sequence only after print completes
+                    const committed = commitPrintedUnitNumber();
+                    // Prepare next displayed number without incrementing storage yet
+                    state.unitNumber = generateUnitNumber();
                 } catch (err) {
                     console.error("Log append failed after print", err);
                     alert("Saving log failed after printing.");

--- a/modules/utils/generators.js
+++ b/modules/utils/generators.js
@@ -3,7 +3,7 @@ export function generateUnitNumber() {
     const effective = apply1201Rule(now);
     const doy = getDayOfYear(effective);
     const doyStr = String(doy).padStart(3, '0');
-    const seq = getAndIncrementDailySequence(effective);
+    const seq = getNextDailySequence(effective);
     const seqStr = String(seq).padStart(3, '0');
     return `AC15${doyStr}${seqStr}`;
 }
@@ -16,6 +16,20 @@ function getDayOfYear(date) {
 }
 
 const SEQ_STORE_KEY = 'unit_seq_store_v1';
+function getNextDailySequence(date) {
+    try {
+        const y = date.getFullYear();
+        const doy = getDayOfYear(date);
+        const key = `${y}-${doy}`;
+        const raw = localStorage.getItem(SEQ_STORE_KEY);
+        const store = raw ? JSON.parse(raw) : {};
+        const current = store[key] || 0;
+        return current + 1;
+    } catch {
+        if (!window.__fallbackSeq) window.__fallbackSeq = 0;
+        return window.__fallbackSeq + 1;
+    }
+}
 function getAndIncrementDailySequence(date) {
     try {
         const y = date.getFullYear();
@@ -48,6 +62,18 @@ function apply1201Rule(date) {
         d.setMinutes(d.getMinutes() - 1);
     }
     return d;
+}
+
+// Commit the currently displayed unit number by incrementing the stored daily sequence.
+// Returns the committed unit number string that was just reserved/printed.
+export function commitPrintedUnitNumber() {
+    const now = new Date();
+    const effective = apply1201Rule(now);
+    const doy = getDayOfYear(effective);
+    const doyStr = String(doy).padStart(3, '0');
+    const seq = getAndIncrementDailySequence(effective);
+    const seqStr = String(seq).padStart(3, '0');
+    return `AC15${doyStr}${seqStr}`;
 }
 
 export function generateBigCode() {


### PR DESCRIPTION
Increment the unit number sequence only after a label has been successfully printed.

---
<a href="https://cursor.com/background-agent?bcId=bc-14cac9a2-f66c-426b-80c5-f46f2c3f08ba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-14cac9a2-f66c-426b-80c5-f46f2c3f08ba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

