### PR TITLE
Generate scanned data details page

### DIFF
--- a/modules/state.js
+++ b/modules/state.js
@@ -15,6 +15,8 @@ export const state = {
     previewTimestamp: null,
     // Whether the next click should reprint the last label
     reprintAvailable: false,
+    // Last scan payload and derived info
+    lastScan: null,
 };
 
 export const screens = {
@@ -23,6 +25,7 @@ export const screens = {
     weights: null,
     preview: null,
     labeldb: null,
+    scan: null,
 };
 
 export function showScreen(name) {

--- a/modules/steps/scan.js
+++ b/modules/steps/scan.js
@@ -1,0 +1,38 @@
+import { state, showScreen } from "../state.js";
+
+export function initScanStep() {
+    const back = document.getElementById("backFromScan");
+    if (back) back.addEventListener("click", () => showScreen("source"));
+    updateScanDetails();
+    document.addEventListener("updateScanDetails", updateScanDetails);
+}
+
+function updateScanDetails() {
+    const data = state.lastScan || {};
+    const parsed = data.parsed || null;
+    const info = data.info || null;
+
+    const unitEl = document.getElementById("scanUnit");
+    const prodEl = document.getElementById("scanProduct");
+    const srcEl = document.getElementById("scanSource");
+    const netEl = document.getElementById("scanNet");
+    const tareEl = document.getElementById("scanTare");
+    const grossEl = document.getElementById("scanGross");
+    const rawEl = document.getElementById("scanRaw");
+
+    const sourceText = (() => {
+        if (!parsed && !info) return "—";
+        const group = info && info.sourceGroup ? String(info.sourceGroup).toUpperCase() : (parsed && parsed.src ? String(parsed.src).toUpperCase() : "");
+        const letter = info && info.sourceLetter ? info.sourceLetter : "";
+        return group || letter ? `${group}${letter ? '-' + letter : ''}` : "—";
+    })();
+
+    if (unitEl) unitEl.textContent = (parsed && parsed.unitNumber) ? parsed.unitNumber : "—";
+    if (prodEl) prodEl.textContent = (parsed && parsed.product) ? parsed.product : "—";
+    if (srcEl) srcEl.textContent = sourceText;
+    if (netEl) netEl.textContent = (parsed && typeof parsed.net === "number") ? parsed.net.toFixed(1) : "—";
+    if (tareEl) tareEl.textContent = (parsed && typeof parsed.tare === "number") ? parsed.tare.toFixed(1) : "—";
+    if (grossEl) grossEl.textContent = (parsed && typeof parsed.gross === "number") ? parsed.gross.toFixed(1) : "—";
+    if (rawEl) rawEl.textContent = data.raw || "—";
+}
+

--- a/screens/scan.html
+++ b/screens/scan.html
@@ -1,0 +1,39 @@
+<section id="screen-scan" class="screen">
+    <header class="screen-header">
+        <button id="backFromScan" class="pill small">Back</button>
+        <h1>Scan Details</h1>
+    </header>
+
+    <div class="card">
+        <div class="muted-text">Most recent scan. No barcode is displayed.</div>
+        <div class="grid" style="grid-template-columns: repeat(3, 1fr); gap:16px;">
+            <div>
+                <div class="w-title">Unit Number</div>
+                <div id="scanUnit">—</div>
+            </div>
+            <div>
+                <div class="w-title">Product</div>
+                <div id="scanProduct">—</div>
+            </div>
+            <div>
+                <div class="w-title">Source</div>
+                <div id="scanSource">—</div>
+            </div>
+            <div>
+                <div class="w-title">Net Weight (lbs)</div>
+                <div id="scanNet">—</div>
+            </div>
+            <div>
+                <div class="w-title">Tare Weight (lbs)</div>
+                <div id="scanTare">—</div>
+            </div>
+            <div>
+                <div class="w-title">Gross Weight (lbs)</div>
+                <div id="scanGross">—</div>
+            </div>
+        </div>
+        <div class="muted-text" style="margin-top:12px">Raw</div>
+        <div id="scanRaw" class="card" style="padding:12px; overflow:auto; white-space:pre-wrap;">—</div>
+    </div>
+</section>
+


### PR DESCRIPTION
Add a dedicated scan details page to display parsed scan data without the barcode, fulfilling the user's request.

---
<a href="https://cursor.com/background-agent?bcId=bc-42fe50c0-13e6-45e7-b92f-b84da2439492">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-42fe50c0-13e6-45e7-b92f-b84da2439492">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

