### PR TITLE
Fix unreadable barcode for Netum scanner

### DIFF
--- a/modules/steps/preview.js
+++ b/modules/steps/preview.js
@@ -137,23 +137,16 @@ function updatePreview() {
     const unit = document.getElementById("unitNumber");
     if (unit) unit.textContent = state.bigCode;
 
-    const canvas = document.getElementById("barcodeCanvas");
-    if (canvas) {
-        const container = canvas.parentElement;
+    const svg = document.getElementById("barcodeSvg");
+    if (svg) {
+        const container = svg.parentElement;
         if (container) {
-            const rect = container.getBoundingClientRect();
-            const dpr = Math.max(1, Math.floor(window.devicePixelRatio || 1));
-            // Because we rotate the canvas 90deg via CSS, swap dimensions
-            const targetWidth = Math.max(1, Math.floor(rect.height * dpr));
-            const targetHeight = Math.max(1, Math.floor(rect.width * dpr));
-            if (canvas.width !== targetWidth || canvas.height !== targetHeight) {
-                canvas.width = targetWidth;
-                canvas.height = targetHeight;
-            }
-            canvas.style.height = "100%";
-            canvas.style.width = "auto";
+            // Let CSS handle rotation and sizing; ensure it fills the column
+            svg.style.height = "100%";
+            svg.style.width = "auto";
+            svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
         }
-        drawBarcode(canvas, buildBarcodePayload());
+        drawBarcode(svg, buildBarcodePayload());
     }
 
     const productEl = document.getElementById("productName");

--- a/screens/preview.html
+++ b/screens/preview.html
@@ -61,7 +61,7 @@
             </div>
 
             <div class="barcode">
-                <canvas id="barcodeCanvas" width="100%" height="80%"></canvas>
+                <svg id="barcodeSvg" xmlns="http://www.w3.org/2000/svg" aria-label="Barcode"></svg>
             </div>
         </div>
         <div class="preview-actions">

--- a/styles.css
+++ b/styles.css
@@ -280,13 +280,18 @@ body {
     display: flex;
     align-items: center;
     justify-content: left;
+    /* Span full width of the label (both columns) and place as its own row */
+    grid-column: 1 / -1;
+    height: 120px;
 }
-.barcode canvas {
+.barcode canvas,
+.barcode svg {
     position: absolute;
     top: 50%;
     left: 50%;
-    transform: translate(-50%, -50%) rotate(90deg);
-    /* size is set via JS by swapping width/height to fit column */
+    transform: translate(-50%, -50%);
+    width: 100%;
+    height: 100%;
 }
 
 .box-number {
@@ -326,8 +331,10 @@ body {
         margin: 0 auto;
         box-shadow: none;
     }
-    .barcode canvas {
-        width: auto;
+    .barcode { height: 1.25in; }
+    .barcode canvas,
+    .barcode svg {
+        width: 100%;
         height: 100%;
     }
 }


### PR DESCRIPTION
Switch barcode rendering to SVG with CODE128 (JsBarcode) to improve scannability for Netum scanners.

The previous canvas-based Code39 barcode was not reliably scannable. This PR adopts SVG with CODE128, increases module width and quiet zones, ensures a white background, and uses a horizontal, full-width layout for better print quality and scanner compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-a85e089f-5fc9-489d-8f2b-be4f585e8143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a85e089f-5fc9-489d-8f2b-be4f585e8143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

