### PR TITLE
Move barcode svg inside label preview

### DIFF
--- a/modules/barcode.js
+++ b/modules/barcode.js
@@ -36,6 +36,11 @@ export function drawBarcode(targetEl, text) {
             if (targetEl && targetEl.tagName && targetEl.tagName.toLowerCase() === 'svg') {
                 targetEl.setAttribute('shape-rendering', 'crispEdges');
                 targetEl.style.background = '#ffffff';
+                // Ensure JsBarcode does not leave transforms that offset the graphic
+                targetEl.removeAttribute('transform');
+                // Fill container
+                targetEl.setAttribute('width', '100%');
+                targetEl.setAttribute('height', '100%');
             }
             return;
         } catch (e) {

--- a/modules/steps/preview.js
+++ b/modules/steps/preview.js
@@ -139,13 +139,11 @@ function updatePreview() {
 
     const svg = document.getElementById("barcodeSvg");
     if (svg) {
-        const container = svg.parentElement;
-        if (container) {
-            // Let CSS handle rotation and sizing; ensure it fills the column
-            svg.style.height = "100%";
-            svg.style.width = "auto";
-            svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
-        }
+        // Ensure the SVG renders fully inside the `.barcode` block
+        svg.style.width = "100%";
+        svg.style.height = "100%";
+        svg.removeAttribute('transform');
+        svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
         drawBarcode(svg, buildBarcodePayload());
     }
 

--- a/styles.css
+++ b/styles.css
@@ -277,19 +277,14 @@ body {
 .barcode {
     position: relative;
     overflow: hidden;
-    display: flex;
-    align-items: center;
-    justify-content: left;
+    display: block;
     /* Span full width of the label (both columns) and place as its own row */
     grid-column: 1 / -1;
     height: 120px;
 }
 .barcode canvas,
 .barcode svg {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
+    display: block;
     width: 100%;
     height: 100%;
 }


### PR DESCRIPTION
Render the barcode SVG inside the label ticket preview instead of outside it.

---
<a href="https://cursor.com/background-agent?bcId=bc-b410401b-cee9-4d80-bd25-5f5cd3ccc627"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b410401b-cee9-4d80-bd25-5f5cd3ccc627"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

