### PR TITLE
Handle lactam and unextracted clicks

### DIFF
--- a/modules/steps/source.js
+++ b/modules/steps/source.js
@@ -26,7 +26,23 @@ export function initSourceStep() {
                 .querySelectorAll("[data-special]")
                 .forEach((x) => x.classList.remove("selected"));
             btn.classList.add("selected");
-            state.source.special = btn.getAttribute("data-special");
+            const special = btn.getAttribute("data-special");
+            state.source.special = special;
+            // Map special to synthetic group/letter for prefix logic
+            state.activeGroup = "other";
+            if (special === "Unextracted") {
+                state.source.other = "UX";
+            } else if (special === "Lactam") {
+                state.source.other = "LT";
+            }
+            // Update displayed unit number with new prefix and skip product selection
+            state.unitNumber = generateUnitNumber(state.activeGroup, state.source.other);
+            state.selectedProduct = null;
+            // Prefill default weights and go directly to weights screen (Enter Tare)
+            document.dispatchEvent(new CustomEvent("prefillDefaultWeights"));
+            showScreen("weights");
+            const gross = document.getElementById("grossWeight");
+            if (gross) gross.focus();
         });
     });
 

--- a/modules/utils/generators.js
+++ b/modules/utils/generators.js
@@ -110,6 +110,9 @@ function resolvePrefix(sourceGroup, sourceLetter) {
     } else if (group === "compound") {
         if (letter === "A") return "AC";
         if (letter === "B") return "BC";
+    } else if (group === "other" || group === "special") {
+        if (letter === "UX") return "UX";
+        if (letter === "LT") return "LT";
     }
     return "AC";
 }


### PR DESCRIPTION
Implement direct navigation to the Enter Tare page with 'UX' or 'LT' prefixes and no product selection for 'Unextracted' and 'Lactam' source types.

---
<a href="https://cursor.com/background-agent?bcId=bc-3e7a28d8-0b9e-416b-81f8-2e4b6728fc85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3e7a28d8-0b9e-416b-81f8-2e4b6728fc85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

